### PR TITLE
Expose classes

### DIFF
--- a/src/NodeHandler.cc
+++ b/src/NodeHandler.cc
@@ -12,6 +12,18 @@ namespace rootJS {
 	NodeHandler *NodeHandler::instance;
 	bool NodeHandler::initialized;
 
+void NodeHandler::exposeGlobalFunctions() {
+}
+
+void NodeHandler::exposeMacros() {
+}
+
+void NodeHandler::exposeClasses() {
+}
+
+void NodeHandler::exposeClass(TClassRef klass) {
+}
+
 	void NodeHandler::initialize(v8::Local<v8::Object> exports, v8::Local<v8::Object> module) {
 		if(!initialized) {
 			NodeApplication::CreateNodeApplication();
@@ -39,7 +51,6 @@ namespace rootJS {
 			/*
 			 * As we iterate through TObjects all these items can be pumped through
 			 * the ObjectProxyFactory
-			 * TODO: Implement something for scalar globals (often constants)
 			 */
 			ObjectProxy *proxy = ObjectProxyFactory::createObjectProxy(*((TGlobal*)global));
 			if(proxy != nullptr) {
@@ -56,4 +67,13 @@ namespace rootJS {
 			}
 		}
 	}
+
+v8::Local<v8::Object> NodeHandler::getExports(void) {
+}
+
+}
+
+void NODE_MODULE(rootjs, NodeHandler::initialize)
+()
+{
 }

--- a/src/NodeHandler.cc
+++ b/src/NodeHandler.cc
@@ -3,6 +3,7 @@
 #include "ObjectProxyFactory.h"
 #include "CallbackHandler.h"
 #include "NodeApplication.h"
+#include "TemplateFactory.h"
 
 #include <TROOT.h>
 #include <string>
@@ -19,14 +20,13 @@ void NodeHandler::exposeMacros() {
 }
 
 void NodeHandler::exposeClasses() {
-	TCollection classes = gROOT->GetListOfClasses();
+	TCollection* classes = gROOT->GetListOfClasses();
 	TIter next(classes);
-	while (TClassRef *clazz = next()) {
-		if (clazz & kIsClass) {
-			exposeClass(*clazz);
+	while (TObject *clazz = next()) {
+		if (((TClass*)clazz)->Property() & kIsClass) {
+			exposeClass(TClassRef((TClass*)clazz));
 		}
 	}
-
 }
 
 void NodeHandler::exposeClass(TClassRef clazz) {

--- a/src/NodeHandler.cc
+++ b/src/NodeHandler.cc
@@ -26,10 +26,8 @@ void NodeHandler::exposeClasses() {
 		if (((TClass*) clazz)->Property() & kIsClass) {
 			std::stack<std::string> stk;
 			//TODO split class name by "::" and put it on a stack
-			this->exports->Set(
-					v8::String::NewFromUtf8(v8::Isolate::GetCurrent(),
-							TClassRef((TClass*) clazz)->GetName()),
-					exposeClassRec(stk.top(), stk)->GetFunction());
+			std::string curname = stk.top();
+			this->exports->Set(curname.c_str(),exposeClassRec(stk.top(), stk)->GetFunction());
 		}
 	}
 }

--- a/src/NodeHandler.cc
+++ b/src/NodeHandler.cc
@@ -6,73 +6,77 @@
 #include "TemplateFactory.h"
 
 #include <TROOT.h>
-#include <string>
-
 namespace rootJS {
 
 NodeHandler *NodeHandler::instance;
 bool NodeHandler::initialized;
-
 void NodeHandler::exposeGlobalFunctions() {
 }
-
 void NodeHandler::exposeMacros() {
 }
 
 void NodeHandler::exposeClasses() {
+	std::map<TClass*, v8::Local<v8::ObjectTemplate>> exposedNamespaces;
 	TCollection* classes = gROOT->GetListOfClasses();
 	TIter next(classes);
-	while (TObject *clazz = next()) {
-		if (((TClass*) clazz)->Property() & kIsClass) {
-			std::string splitname = (clazz->GetName());
-			std::stack stk = splitClassName(splitname);
-			std::string curname = stk.top();
-			this->exports->Set(curname.c_str(),
-					exposeClassRec(stk.top(), stk)->GetFunction());
+	//iterate over all classes
+	while (TClass *clazz = (TClass*) next()) {
+		//get full name of class and split it by "::" to get the namespaces the class resides in
+		std::string splitname = (clazz->GetName());
+		std::queue<std::string> que = splitClassName(splitname);
+		std::string curname = que.front();
+
+		//if it is in the top namespace just create a template and set it in exports
+		if ((que.size() == 1)) {
+			if (clazz->Property() & kIsClass) {
+				this->exports->Set(
+						v8::String::NewFromUtf8(v8::Isolate::GetCurrent(),
+								curname.c_str()),
+						TemplateFactory::createTemplate(TClassRef(clazz))->GetFunction());
+			}
+			if (clazz->Property() & kIsNamespace) {
+				this->exports->Set(
+						v8::String::NewFromUtf8(v8::Isolate::GetCurrent(),
+								curname.c_str()),
+						createNamespace(clazz, exposedNamespaces)->NewInstance());
+			}
+		} else {
+			//only process classes and namespaces
+			if ((clazz->Property() & kIsNamespace)
+					|| (clazz->Property() & kIsClass)) {
+
+				DictFuncPtr_t dickFunc = gClassTable->GetDict(curname.c_str());
+				TClass* recclass = dickFunc();
+					//TODO exception magic
+
+				this->exports->Set(
+						v8::String::NewFromUtf8(v8::Isolate::GetCurrent(),
+								curname.c_str()),
+						exposeClassRec(recclass, que, exposedNamespaces)->NewInstance());
+			}
 		}
 	}
 }
 
-v8::Local<v8::FunctionTemplate> NodeHandler::exposeClassRec(std::string name,
-		std::stack<std::string>& stk) {
-	std::string curname = name;
-	stk.pop();
-	DictFuncPtr_t dictFunc = gClassTable->GetDict(name.c_str());
-	//TODO implement map to avoid duplicates and check for double assignments of identical
-	// classes to the same class/name space and avoid them
-	if (dictFunc == nullptr) {
-		//TODO throw exception
+v8::Local<v8::ObjectTemplate> NodeHandler::exposeClassRec(TClass* curclass,
+		std::queue<std::string>& que,
+		std::map<TClass*, v8::Local<v8::ObjectTemplate>>& exposedNamespaces) {
+	if (que.empty()) {
+		return createNamespace(curclass, exposedNamespaces);
 	}
-	if (stk.empty()) {
-		return TemplateFactory::createTemplate(TClassRef(dictFunc()));
-	} else {
-		v8::Local<v8::FunctionTemplate> rectmpl = exposeClassRec(stk.top(),
-				stk);
-		v8::Local<v8::FunctionTemplate> curtmpl =
-				TemplateFactory::createTemplate(TClassRef(dictFunc()));
-		curtmpl->Set(v8::Isolate::GetCurrent(), curname.c_str(), rectmpl);
-		return curtmpl;
-	}
-}
 
-std::stack<std::string> NodeHandler::splitClassName(std::string name) {
+	que.pop();
+	DictFuncPtr_t dickFunc = gClassTable->GetDict(que.front().c_str());
+	TClass* recclass = dickFunc();
+	v8::Local<v8::ObjectTemplate>  curtmpl = createNamespace(curclass, exposedNamespaces);
+	if (recclass->Property() & kIsNamespace) {
+		v8::Local<v8::ObjectTemplate> rectmpl = exposeClassRec(recclass, que,
+				exposedNamespaces);
+		curtmpl->Set(v8::Isolate::GetCurrent(), curclass->GetName(),
+				rectmpl->NewInstance());
+	}
+	return curtmpl;
 
-	std::string delimiter = "::";
-	std::stack<std::string> stk;
-	std::stack<std::string> revstk;
-	size_t pos = 0;
-	std::string token;
-	while ((pos = name.find(delimiter)) != std::string::npos) {
-		token = name.substr(0, pos);
-		stk.push(token);
-		name.erase(0, pos + delimiter.length());
-	}
-	stk.push(name);
-	while (!stk.empty()) {
-		revstk.push(stk.top());
-		stk.pop();
-	}
-	return revstk;
 }
 
 void NodeHandler::initialize(v8::Local<v8::Object> exports,
@@ -121,6 +125,22 @@ void NodeHandler::exposeGlobals() {
 					&CallbackHandler::globalSetterCallback);
 		}
 	}
+}
+
+std::queue<std::string> NodeHandler::splitClassName(std::string name) {
+
+	std::string delimiter = "::";
+	std::queue<std::string> que;
+	size_t pos = 0;
+	std::string token;
+	while ((pos = name.find(delimiter)) != std::string::npos) {
+		token = name.substr(0, pos);
+		que.push(token);
+		name.erase(0, pos + delimiter.length());
+	}
+	que.push(name);
+
+	return que;
 }
 
 }

--- a/src/NodeHandler.h
+++ b/src/NodeHandler.h
@@ -1,6 +1,7 @@
 #ifndef NODE_HANDLER_H
 #define NODE_HANDLER_H
 
+#include <stack>
 #include <v8.h>
 #include <node.h>
 #include <TClassRef.h>
@@ -32,6 +33,7 @@ namespace rootJS {
 			void exposeMacros();
 			void exposeClasses();
 			void exposeClass(TClassRef klass);
+			v8::Local<v8::FunctionTemplate> exposeClassRec(std::string,std::stack<std::string>&);
 
 		public:
 			static void initialize(v8::Local<v8::Object>, v8::Local<v8::Object>);

--- a/src/NodeHandler.h
+++ b/src/NodeHandler.h
@@ -26,12 +26,14 @@ namespace rootJS {
 
 			/* Private constructor - Singleton */
 			NodeHandler(v8::Local<v8::Object>);
+			std::stack<std::string> splitClassName (std::string);
 
 			void exposeROOT();
 			void exposeGlobalFunctions();
 			void exposeGlobals();
 			void exposeMacros();
 			void exposeClasses();
+			//TODO check if this method is still needed
 			void exposeClass(TClassRef klass);
 			v8::Local<v8::FunctionTemplate> exposeClassRec(std::string,std::stack<std::string>&);
 

--- a/src/NodeHandler.h
+++ b/src/NodeHandler.h
@@ -1,10 +1,12 @@
 #ifndef NODE_HANDLER_H
 #define NODE_HANDLER_H
 
-#include <stack>
+#include <queue>
 #include <v8.h>
 #include <node.h>
 #include <TClassRef.h>
+#include <map>
+#include <queue>
 
 namespace rootJS {
 
@@ -20,14 +22,15 @@ namespace rootJS {
 			 */
 			static NodeHandler *instance;
 			/**
-			 * THe exports object to be sent back to node
+			 * The exports object to be sent back to node
 			 */
 			v8::Local<v8::Object> exports;
 
 			/* Private constructor - Singleton */
 			NodeHandler(v8::Local<v8::Object>);
-			std::stack<std::string> splitClassName (std::string);
 
+
+			std::queue<std::string> splitClassName (std::string);
 			void exposeROOT();
 			void exposeGlobalFunctions();
 			void exposeGlobals();
@@ -35,7 +38,9 @@ namespace rootJS {
 			void exposeClasses();
 			//TODO check if this method is still needed
 			void exposeClass(TClassRef klass);
-			v8::Local<v8::FunctionTemplate> exposeClassRec(std::string,std::stack<std::string>&);
+			v8::Local<v8::ObjectTemplate> exposeClassRec(TClass*,std::queue<std::string>&,std::map<TClass*,v8::Local<v8::ObjectTemplate>>&);
+			//TODO move this to the TemplateFactory?
+			v8::Local<v8::ObjectTemplate> createNamespace(TClass*,std::map<TClass*,v8::Local<v8::ObjectTemplate>>&);
 
 		public:
 			static void initialize(v8::Local<v8::Object>, v8::Local<v8::Object>);


### PR DESCRIPTION
Created recursive class exporting in Nodehandler.
It utilizes the class names provided by gROOT to trigger template creation for the classes and their respective namespaces.
For example: 
"foo:bar:classname" results in 3 templates created: two namespaces "foo" and "bar" with bar accessible through foo and a class "classname" in bar. foo is then set in the export object so one can access it through something akin to: root.foo.bar.classname() 

What's missing:
-  a map to store the created namespaces/classes so no duplicates are created
-  spliiting the names by '::' to get the classes/namespaces for recursive creation
