### PR TITLE
Expose Class/Namespaces in correct hierarchies

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -23,6 +23,7 @@
 				'src/BooleanProxy.cc',
 				'src/NumberProxy.cc',
 				'src/FunctionProxyFactory.cc',
+				'src/ClassExposer.cc',
 				'src/CallbackHandler.cc',
 				'src/NodeApplication.cc',
 				'src/AsyncRunner.cc',

--- a/src/ClassExposer.cc
+++ b/src/ClassExposer.cc
@@ -1,0 +1,21 @@
+/*
+ * ClassExposer.cc
+ *
+ *  Created on: Feb 11, 2016
+ *      Author: theo
+ */
+
+#include "ClassExposer.h"
+
+namespace rootJS {
+
+ClassExposer::~ClassExposer() {
+	// TODO Auto-generated destructor stub
+}
+
+ClassExposer::ClassExposer() {
+	// TODO Auto-generated constructor stub
+
+}
+
+} /* namespace rootJS */

--- a/src/ClassExposer.cc
+++ b/src/ClassExposer.cc
@@ -12,6 +12,8 @@
 #include <TGlobal.h>
 #include <TClass.h>
 #include <TClassTable.h>
+#include <iostream>
+
 namespace rootJS {
 
 ClassExposer::~ClassExposer() {
@@ -50,12 +52,12 @@ void ClassExposer::expose(TClass* clazz,v8::Local<v8::Object> exports) {
 				}
 				TClass* curclazz = funcPtr();
 				if(curclazz->Property() & kIsNamespace) {
-					exports->Set(v8::String::NewFromUtf8(v8::Isolate::GetCurrent(), nameque.front().c_str()),
-								 TemplateFactory::getInstance(curclazz));
+					obj = TemplateFactory::getInstance(curclazz);
+					exports->Set(v8::String::NewFromUtf8(v8::Isolate::GetCurrent(), nameque.front().c_str()), obj);
 				}
 				if(curclazz->Property() & kIsClass) {
-					exports->Set(v8::String::NewFromUtf8(v8::Isolate::GetCurrent(), nameque.front().c_str()),
-								 TemplateFactory::getConstructor(curclazz));
+					obj = TemplateFactory::getConstructor(curclazz);
+					exports->Set(v8::String::NewFromUtf8(v8::Isolate::GetCurrent(), nameque.front().c_str()), obj );
 				}
 				//TODO figure out if there are other cases as well
 				}

--- a/src/ClassExposer.cc
+++ b/src/ClassExposer.cc
@@ -4,18 +4,69 @@
  *  Created on: Feb 11, 2016
  *      Author: theo
  */
-
+#include <vector>
+#include <queue>
 #include "ClassExposer.h"
-
+#include "TROOT.h"
+#include <TGlobal.h>
+#include <TClass.h>
+#include <TClassTable.h>
 namespace rootJS {
 
 ClassExposer::~ClassExposer() {
-	// TODO Auto-generated destructor stub
 }
 
-ClassExposer::ClassExposer() {
-	// TODO Auto-generated constructor stub
+void ClassExposer::expose(TClass* clazz,v8::Local<v8::Object> exports) {
+	std::vector<std::string> vec;
+	splitClassName(std::string(clazz->GetName()), vec);//ROOT::Math::Class
+		std::queue<std::string> pathque;
+		std::queue<std::string> nameque;
+
+		std::string buff = vec[0];
+		nameque.push(buff);
+		pathque.push(buff);
+
+		//setting up the names under which the object are exported and their names in ROOT
+		for(int i = 1; i < vec.size();i++){
+			std::string buff = vec[i];
+			nameque.push(buff);
+			std::string pathbuff = pathque.back();
+			pathbuff.append("::");
+			pathbuff.append(buff);
+			pathque.push(pathbuff);
+		}
+
+	v8::Local<v8::Object> obj;
+		while(!nameque.empty()){
+			obj = exports->Get(	v8::String::NewFromUtf8(v8::Isolate::GetCurrent(),nameque.front().c_str()));
+			if(obj.IsEmpty()){
+				DictFuncPtr_t funcPtr = gClassTable->GetDict(pathque.front().c_str());
+				if(funcPtr = nullptr) {
+					//TODO throw something
+				}
+				
+			}
+
+		}
+
+
+
 
 }
+
+std::vector<std::string> ClassExposer::splitClassName(std::string name, std::vector<std::string>& vec) {
+
+		std::string delimiter = "::";
+	 	size_t pos = 0;
+	 	std::string token;
+	 	while ((pos = name.find(delimiter)) != std::string::npos) {
+	 		token = name.substr(0, pos);
+	 		vec.push_back(token);
+	 		name.erase(0, pos + delimiter.length());
+	 	}
+	 	vec.push_back(name);
+
+	 	return vec;
+	 }
 
 } /* namespace rootJS */

--- a/src/ClassExposer.cc
+++ b/src/ClassExposer.cc
@@ -19,16 +19,19 @@ ClassExposer::~ClassExposer() {
 
 void ClassExposer::expose(TClass* clazz,v8::Local<v8::Object> exports) {
 	std::vector<std::string> vec;
-	splitClassName(std::string(clazz->GetName()), vec);//ROOT::Math::Class
+	std::string name(clazz->GetName());
+	if(name.find('<') != std::string::npos){
+		return;
+	}
+	splitClassName(name, vec);//ROOT::Math::Class
 		std::queue<std::string> pathque;
 		std::queue<std::string> nameque;
-
 		std::string buff = vec[0];
 		nameque.push(buff);
 		pathque.push(buff);
 
 		//setting up the names under which the object are exported and their names in ROOT
-		for(int i = 1; i < vec.size();i++){
+		for(uint i = 1; i < vec.size();i++){
 			std::string buff = vec[i];
 			nameque.push(buff);
 			std::string pathbuff = pathque.back();

--- a/src/ClassExposer.cc
+++ b/src/ClassExposer.cc
@@ -26,6 +26,7 @@ void ClassExposer::expose(TClass* clazz,v8::Local<v8::Object> exports)  throw(st
 	std::string name(clazz->GetName());
 	if(name.find('<') != std::string::npos){
 		//TODO Handle templates
+		Toolbox::logInfo(std::string("omitting template ").append(clazz->GetName()));
 		return;
 	}
 	splitClassName(name, vec);

--- a/src/ClassExposer.cc
+++ b/src/ClassExposer.cc
@@ -39,20 +39,20 @@ void ClassExposer::expose(TClass* clazz,v8::Local<v8::Object> exports) {
 
 	v8::Local<v8::Object> obj;
 		while(!nameque.empty()){
-			obj = exports->Get(	v8::String::NewFromUtf8(v8::Isolate::GetCurrent(),nameque.front().c_str()));
+			obj = v8::Local<v8::Object>::Cast(exports->Get(v8::String::NewFromUtf8(v8::Isolate::GetCurrent(),nameque.front().c_str())));
 			if(obj.IsEmpty()){ //if there was no object set yet create one and set it
 				DictFuncPtr_t funcPtr(gClassTable->GetDict(pathque.front().c_str()));
-				if(funcPtr = nullptr) {
+				if(funcPtr == nullptr) {
 					//TODO throw something
 				}
-				TClass* clazz = funcPtr();
-				if(clazz->Property() & kIsNamespace) {
+				TClass* curclazz = funcPtr();
+				if(curclazz->Property() & kIsNamespace) {
 					exports->Set(v8::String::NewFromUtf8(v8::Isolate::GetCurrent(), nameque.front().c_str()),
-								 TemplateFactory::getInstance(clazz));
+								 TemplateFactory::getInstance(curclazz));
 				}
-				if(clazz->Property() & kIsClass) {
+				if(curclazz->Property() & kIsClass) {
 					exports->Set(v8::String::NewFromUtf8(v8::Isolate::GetCurrent(), nameque.front().c_str()),
-								 TemplateFactory::getConstructor(clazz));
+								 TemplateFactory::getConstructor(curclazz));
 				}
 				//TODO figure out if there are other cases as well
 				}

--- a/src/ClassExposer.cc
+++ b/src/ClassExposer.cc
@@ -10,6 +10,7 @@
 #include "stdexcept"
 #include "TROOT.h"
 #include "TemplateFactory.h"
+#include "Toolbox.h"
 #include <TGlobal.h>
 #include <TClass.h>
 #include <TClassTable.h>
@@ -49,15 +50,18 @@ void ClassExposer::expose(TClass* clazz,v8::Local<v8::Object> exports)  throw(st
 			if (!scope->Has(v8::String::NewFromUtf8(v8::Isolate::GetCurrent(), nameque.front().c_str()))) {
 				DictFuncPtr_t funcPtr(gClassTable->GetDict(pathque.front().c_str()));
 				if (funcPtr == nullptr) {
+					Toolbox::logInfo(std::string("creating stub namespace: ").append(pathque.front()));
 					scope->Set(v8::String::NewFromUtf8(v8::Isolate::GetCurrent(), nameque.front().c_str()), obj->New(v8::Isolate::GetCurrent()));
 				} else{
 				try {
 					TClass *curclazz = funcPtr();
 					if (curclazz->Property() & kIsNamespace) {
+						Toolbox::logInfo(std::string("loading namespace ").append(curclazz->GetName()));
 						obj = TemplateFactory::getInstance(curclazz);
 						scope->Set(v8::String::NewFromUtf8(v8::Isolate::GetCurrent(), nameque.front().c_str()), obj);
 					}
 					if (curclazz->Property() & kIsClass) {
+						Toolbox::logInfo(std::string("loading class ").append(curclazz->GetName()));
 						obj = TemplateFactory::getConstructor(curclazz);
 						scope->Set(v8::String::NewFromUtf8(v8::Isolate::GetCurrent(), nameque.front().c_str()), obj);
 					}

--- a/src/ClassExposer.h
+++ b/src/ClassExposer.h
@@ -10,7 +10,7 @@ class ClassExposer {
 public:
 	virtual ~ClassExposer();
 
-	static void expose(TClass*,v8::Local<v8::Object>);
+	static void expose(TClass*,v8::Local<v8::Object>) throw(std::invalid_argument);
 	static std::vector<std::string> splitClassName(std::string name, std::vector<std::string>& vec);
 private:
 	ClassExposer();

--- a/src/ClassExposer.h
+++ b/src/ClassExposer.h
@@ -1,0 +1,18 @@
+#ifndef SRC_CLASSEXPOSER_H_
+#define SRC_CLASSEXPOSER_H_
+
+#include <TROOT.h>
+
+namespace rootJS {
+
+class ClassExposer {
+public:
+	virtual ~ClassExposer();
+	ClassExposer();
+	static void expose(TClass*);
+
+};
+
+} /* namespace rootJS */
+
+#endif /* SRC_CLASSEXPOSER_H_ */

--- a/src/ClassExposer.h
+++ b/src/ClassExposer.h
@@ -2,15 +2,18 @@
 #define SRC_CLASSEXPOSER_H_
 
 #include <TROOT.h>
+#include <v8.h>
 
 namespace rootJS {
 
 class ClassExposer {
 public:
 	virtual ~ClassExposer();
-	ClassExposer();
-	static void expose(TClass*);
 
+	static void expose(TClass*,v8::Local<v8::Object>);
+	static std::vector<std::string> splitClassName(std::string name, std::vector<std::string>& vec);
+private:
+	ClassExposer();
 };
 
 } /* namespace rootJS */

--- a/src/NodeHandler.cc
+++ b/src/NodeHandler.cc
@@ -100,17 +100,18 @@ void NodeHandler::exposeGlobalFunctions() throw (std::invalid_argument) {
 void NodeHandler::exposeClasses() throw (std::invalid_argument) {
 	for (int i = 0; i < gClassTable->Classes(); i++) {
 		DictFuncPtr_t funcPtr = gClassTable->GetDict(gClassTable->At(i));
+		Toolbox::logInfo(std::string("loading class").append(clazz->GetName()));
 		if (funcPtr == nullptr) {
 			throw std::invalid_argument(
 					std::string("Specified class is null."));
 		}
-
 		TClass *clazz = funcPtr(); // call dictionary function on class
+
+
 		if (clazz == nullptr || !clazz->IsLoaded()) {
 			throw std::invalid_argument(
 					std::string("Specified class is not loaded."));
 		}
-		const char* name = clazz->GetName();//TODO remove this line
 		if (((std::string) clazz->GetName()).find(":") == std::string::npos) {
 			if ((clazz->Property() & kIsClass)) {
 				this->exports->Set(

--- a/src/NodeHandler.cc
+++ b/src/NodeHandler.cc
@@ -110,7 +110,7 @@ void NodeHandler::exposeClasses() throw (std::invalid_argument) {
 			throw std::invalid_argument(
 					std::string("Specified class is not loaded."));
 		}
-		const char* name = clazz->GetName();
+		const char* name = clazz->GetName();//TODO remove this line
 		if (((std::string) clazz->GetName()).find(":") == std::string::npos) {
 			if ((clazz->Property() & kIsClass)) {
 				this->exports->Set(

--- a/src/NodeHandler.cc
+++ b/src/NodeHandler.cc
@@ -1,13 +1,13 @@
 #include "NodeHandler.h"
-
+#include <v8.h>
 #include "NodeApplication.h"
 #include "ObjectProxy.h"
 #include "ObjectProxyFactory.h"
 #include "CallbackHandler.h"
 #include "Toolbox.h"
-
+#include "ClassExposer.h"
 #include <string>
-
+#include <iostream>
 #include <TROOT.h>
 #include <TInterpreter.h>
 #include <TFunction.h>
@@ -15,124 +15,117 @@
 #include <TClass.h>
 #include <TClassTable.h>
 
-namespace rootJS
-{
+namespace rootJS {
 
-	NodeHandler *NodeHandler::instance;
-	bool NodeHandler::initialized;
+NodeHandler *NodeHandler::instance;
+bool NodeHandler::initialized;
 
-	void NodeHandler::initialize(v8::Local<v8::Object> exports, v8::Local<v8::Object> module)
-	{
-		if(!initialized)
-		{
-			NodeApplication::CreateNodeApplication();
-			ObjectProxyFactory::initializeProxyMap();
-			instance = new NodeHandler(exports);
-			instance->exposeROOT();
-		}
-		else
-		{
-			Toolbox::throwException("The NodeHandler can only be initialized once.");
-		}
+void NodeHandler::initialize(v8::Local<v8::Object> exports,
+		v8::Local<v8::Object> module) {
+
+	if (!initialized) {
+
+		NodeApplication::CreateNodeApplication();
+		ObjectProxyFactory::initializeProxyMap();
+		instance = new NodeHandler(exports);
+		instance->exposeROOT();
+
+	} else {
+		Toolbox::throwException(
+				"The NodeHandler can only be initialized once.");
 	}
+}
 
-	NodeHandler::NodeHandler(v8::Local<v8::Object> exports)
-	{
-		this->exports = exports;
+NodeHandler::NodeHandler(v8::Local<v8::Object> exports) {
+	this->exports = exports;
+}
+
+void NodeHandler::exposeROOT() {
+	gInterpreter->SetClassAutoloading(kTRUE);
+
+	try {
+		exposeGlobals();
+		exposeGlobalFunctions();
+		exposeMacros();
+
+		exposeClasses();
+	} catch (const std::invalid_argument& e) {
+		Toolbox::throwException(e.what());
+		return;
 	}
+}
 
-	void NodeHandler::exposeROOT()
-	{
-		gInterpreter->SetClassAutoloading(kTRUE);
+void NodeHandler::exposeMacros() throw (std::invalid_argument) {
+	// TODO
+}
 
-		try
-		{
-			exposeGlobals();
-			exposeGlobalFunctions();
-			exposeMacros();
-			exposeClasses();
-		}
-		catch(const std::invalid_argument& e)
-		{
-			Toolbox::throwException(e.what());
-			return;
-		}
-	}
+void NodeHandler::exposeGlobals() throw (std::invalid_argument) {
+	TCollection *globals = gROOT->GetListOfGlobals(kTRUE);
+	TIter next(globals);
 
-	void NodeHandler::exposeMacros() throw(std::invalid_argument)
-	{
-		// TODO
-	}
-
-	void NodeHandler::exposeGlobals() throw(std::invalid_argument)
-	{
-		TCollection *globals = gROOT->GetListOfGlobals(kTRUE);
-		TIter next(globals);
-
-		while(TGlobal *global = (TGlobal*) next())
-		{
-			ObjectProxy *proxy = ObjectProxyFactory::createObjectProxy(*global);
-			if(proxy != nullptr)
-			{
-				CallbackHandler::registerGlobalObject(std::string(global->GetName()), proxy);
-				this->exports->SetAccessor(v8::String::NewFromUtf8(v8::Isolate::GetCurrent(), global->GetName()),
-				                           CallbackHandler::globalGetterCallback, CallbackHandler::globalSetterCallback);
-			}
+	while (TGlobal *global = (TGlobal*) next()) {
+		ObjectProxy *proxy = ObjectProxyFactory::createObjectProxy(*global);
+		if (proxy != nullptr) {
+			CallbackHandler::registerGlobalObject(
+					std::string(global->GetName()), proxy);
+			this->exports->SetAccessor(
+					v8::String::NewFromUtf8(v8::Isolate::GetCurrent(),
+							global->GetName()),
+					CallbackHandler::globalGetterCallback,
+					CallbackHandler::globalSetterCallback);
 		}
 	}
+}
 
-	void NodeHandler::exposeGlobalFunctions() throw(std::invalid_argument)
-	{
-		TCollection *functions = gROOT->GetListOfGlobalFunctions(kTRUE);
+void NodeHandler::exposeGlobalFunctions() throw (std::invalid_argument) {
+	TCollection *functions = gROOT->GetListOfGlobalFunctions(kTRUE);
 
-		TIter next(functions);
-		while(TFunction *function = (TFunction*) next())
-		{
-			if(!function->IsValid())
-			{
-				Toolbox::logError("Invalid global function found.");
+	TIter next(functions);
+	while (TFunction *function = (TFunction*) next()) {
+		if (!function->IsValid()) {
+			Toolbox::logError("Invalid global function found.");
+			continue;
+		}
+
+		v8::Local<v8::Value> data = CallbackHandler::createFunctionCallbackData(
+				function->GetName(), nullptr);
+		exports->Set(
+				v8::String::NewFromUtf8(v8::Isolate::GetCurrent(),
+						function->GetName()),
+				v8::Function::New(v8::Isolate::GetCurrent(),
+						CallbackHandler::globalFunctionCallback, data));
+	}
+}
+
+void NodeHandler::exposeClasses() throw (std::invalid_argument) {
+	for (int i = 0; i < gClassTable->Classes(); i++) {
+		DictFuncPtr_t funcPtr = gClassTable->GetDict(gClassTable->At(i));
+		if (funcPtr == nullptr) {
+			throw std::invalid_argument(
+					std::string("Specified class is null."));
+		}
+
+		TClass *clazz = funcPtr(); // call dictionary function on class
+		if (clazz == nullptr || !clazz->IsLoaded()) {
+			throw std::invalid_argument(
+					std::string("Specified class is not loaded."));
+		}
+		const char* name = clazz->GetName();
+		if (((std::string) clazz->GetName()).find(":") == std::string::npos) {
+			if ((clazz->Property() & kIsClass)) {
+				this->exports->Set(
+					v8::String::NewFromUtf8(v8::Isolate::GetCurrent(), clazz->GetName()), TemplateFactory::getConstructor(clazz));
+				continue;
+		}
+			if((clazz->Property() & kIsNamespace)){
+				this->exports->Set(v8::String::NewFromUtf8(v8::Isolate::GetCurrent(),clazz->GetName()),TemplateFactory::getInstance(clazz));
 				continue;
 			}
-
-			v8::Local<v8::Value> data = CallbackHandler::createFunctionCallbackData(function->GetName(), nullptr);
-			exports->Set(v8::String::NewFromUtf8(v8::Isolate::GetCurrent(), function->GetName()),
-			             v8::Function::New(v8::Isolate::GetCurrent(), CallbackHandler::globalFunctionCallback, data));
+		}
+		else {
+			ClassExposer::expose(clazz, exports);
 		}
 	}
-
-	void NodeHandler::exposeClasses() throw(std::invalid_argument)
-	{
-		for (int i = 0; i < gClassTable->Classes(); i++)
-		{
-			DictFuncPtr_t funcPtr = gClassTable->GetDict(gClassTable->At(i));
-			if (funcPtr == nullptr)
-			{
-				throw std::invalid_argument(std::string("Specified class is null."));
-			}
-
-			TClass *clazz = funcPtr(); // call dictionary function on class
-			if (clazz == nullptr || !clazz->IsLoaded())
-			{
-				throw std::invalid_argument(std::string("Specified class is not loaded."));
-			}
-			if (((std::string) clazz->GetName()).find(":") == std::string::npos)
-			{
-
-				if (clazz->Property() & kIsNamespace)
-				{
-					this->exports->Set(v8::String::NewFromUtf8(
-					                       v8::Isolate::GetCurrent(), clazz->GetName()),TemplateFactory::getInstance(clazz));
-					continue;
-				}
-
-			}
-
-			if (clazz->Property() & kIsClass)
-			{
-				this->exports->Set(v8::String::NewFromUtf8(
-				                       v8::Isolate::GetCurrent(), clazz->GetName()),TemplateFactory::getConstructor(clazz));
-			}
-		}
-	}
+}
 
 }

--- a/src/NodeHandler.cc
+++ b/src/NodeHandler.cc
@@ -100,13 +100,11 @@ void NodeHandler::exposeGlobalFunctions() throw (std::invalid_argument) {
 void NodeHandler::exposeClasses() throw (std::invalid_argument) {
 	for (int i = 0; i < gClassTable->Classes(); i++) {
 		DictFuncPtr_t funcPtr = gClassTable->GetDict(gClassTable->At(i));
-		Toolbox::logInfo(std::string("loading class").append(clazz->GetName()));
 		if (funcPtr == nullptr) {
 			throw std::invalid_argument(
 					std::string("Specified class is null."));
 		}
 		TClass *clazz = funcPtr(); // call dictionary function on class
-
 
 		if (clazz == nullptr || !clazz->IsLoaded()) {
 			throw std::invalid_argument(
@@ -114,11 +112,13 @@ void NodeHandler::exposeClasses() throw (std::invalid_argument) {
 		}
 		if (((std::string) clazz->GetName()).find(":") == std::string::npos) {
 			if ((clazz->Property() & kIsClass)) {
+				Toolbox::logInfo(std::string("loading class ").append(clazz->GetName()));
 				this->exports->Set(
-					v8::String::NewFromUtf8(v8::Isolate::GetCurrent(), clazz->GetName()), TemplateFactory::getConstructor(clazz));
+				v8::String::NewFromUtf8(v8::Isolate::GetCurrent(), clazz->GetName()), TemplateFactory::getConstructor(clazz));
 				continue;
 		}
 			if((clazz->Property() & kIsNamespace)){
+				Toolbox::logInfo(std::string("loading namespace ").append(clazz->GetName()));
 				this->exports->Set(v8::String::NewFromUtf8(v8::Isolate::GetCurrent(),clazz->GetName()),TemplateFactory::getInstance(clazz));
 				continue;
 			}

--- a/test/namespaces.js
+++ b/test/namespaces.js
@@ -1,0 +1,13 @@
+require('should');
+var root = require('../index');
+
+
+describe('Namespaces', function() {
+  describe('exposing', function() {
+	  it('should have the property ROOT.Detail.TSchemaRuleSet', function() {
+		  (function() {
+			  should.not.equal(root.ROOT.Detail.TSchemaRuleSet, undefined);
+		  }).should.not.throw();
+	  });
+  });
+});


### PR DESCRIPTION
Namespaces and Classes present in the gClasstable at initialization will be exposed with the correct class structure reflected within the exported node.js object.
What's left to do:
- [ ] actually implement namespace creation in template factory
- [ ]  create possibility to load class after initialialization into the existing exports object while preserving the structure it got during in
